### PR TITLE
Partial: Revert: Adapt, update and retire some features for the 15-qpr2

### DIFF
--- a/res/values/custom_arrays.xml
+++ b/res/values/custom_arrays.xml
@@ -1418,12 +1418,12 @@
    <string-array name="quickswitch_launcher_entries">
         <item>Ortus Launcher</item>
         <item>Pixel Launcher</item>
-        <!-- <item>Lawnchair Launcher</item> -->
+        <item>Lawnchair Launcher</item>
     </string-array>
     <string-array name="quickswitch_launcher_values" translatable="false">
         <item>0</item>
         <item>1</item>
-        <!-- <item>2</item> -->
+        <item>2</item>
     </string-array>
     
     <string-array name="clock_style_entries">


### PR DESCRIPTION
partial revert of this commit 414039f18ed78bd437b21b051e9bb7e668b0cfd1

Causes an ArrayIndexOutOfBoundsException error breaking the built in Quickswitch feature The assumption is that we want to keep Lawnchair Launcher as an option to switch to as it is very popular. This is also one of the features users have come to enjoy from this project